### PR TITLE
Adding Dockerfile

### DIFF
--- a/library/DOCKER.md
+++ b/library/DOCKER.md
@@ -26,7 +26,7 @@ Build an image to run an example file:
 
 ```
 FROM scroll-phat
-CMD ["python", "example/count.py", "99"]
+CMD ["python", "examples/count.py", "99"]
 ```
 
 **Build example**
@@ -36,7 +36,7 @@ docker build -t scroll-phat/count .
 
 **Running example**
 ```
-docker run scroll-phat/count
+docker run --privileged scroll-phat/count
 ```
 
 ### Testing use-case

--- a/library/DOCKER.md
+++ b/library/DOCKER.md
@@ -1,0 +1,62 @@
+Fully tested Dockerfile for using scroll-phat library without needing to install it on base system.
+
+> This is unobtrusively squirrelled away in the library folder for those who are curious and interested in learning about Docker and the PI. Tested with the count.py example.
+
+Building
+```
+$ cd library
+$ ./docker_build.sh
+```
+
+Running in repl
+```
+$ docker run -ti --privileged scroll-phat
+Python 2.7.9 (default, Mar  8 2015, 00:52:26) 
+[GCC 4.9.2] on linux2
+Type "help", "copyright", "credits" or "license" for more information.
+>>> import scrollphat
+>>> scrollphat.set_pixel(1,1,True)
+>>> scrollphat.update()
+>>> 
+```
+
+Build an image to run an example file:
+
+**Dockerfile**
+
+```
+FROM scroll-phat
+CMD ["python", "example/count.py", "99"]
+```
+
+**Build example**
+```
+docker build -t scroll-phat/count .
+```
+
+**Running example**
+```
+docker run scroll-phat/count
+```
+
+### Testing use-case
+
+* Remove all traces of scroll-phat egg from base system
+* Use Dockerfile to run `setup.py install` then run a number of the examples to see whether they are working fully.
+
+* Can easily have an image with only Python2, only Python3 and both - for testing.
+
+Previously this would have involved hacks and work-arounds. 
+
+### Deployment use-case
+
+* Once i2c is configured on the base system, nothing needs to be installed on top at all
+* Everything can be installed straight into the image - even at different versions
+* Can be used as a base image to be derived from for a personal project with scroll-phat
+
+### Can be used to distribute a tested/working installation
+
+* Maintainer builds image
+* Maintainer uploads to Docker Hub
+* Consumer/enthusiast pulls image, runs exactly the same as it did for the maintainer.
+

--- a/library/Dockerfile
+++ b/library/Dockerfile
@@ -1,0 +1,18 @@
+FROM alexellis2/python-gpio:armv6
+# This base image will be fetched automatically from the Docker Hub
+# https://hub.docker.com/r/alexellis2/python-gpio/
+
+# For instructions on installing Docker on the PI Zero visit below tutorial
+# http://blog.alexellis.io/dockerswarm-pizero/
+
+RUN apt-get update && \
+    apt-get -qy install python-smbus i2c-tools
+
+ADD ./examples  ./examples
+ADD ./library   ./library
+ADD ./tools     ./tools
+
+RUN cd library && \
+    python setup.py install
+
+CMD ["python"]

--- a/library/build_docker.sh
+++ b/library/build_docker.sh
@@ -1,0 +1,7 @@
+echo "Building image to your library as scroll-phat"
+cp Dockerfile ../
+cd ../
+docker build -t scroll-phat .
+rm Dockerfile
+
+


### PR DESCRIPTION
*Documentation as repeated in `DOCKER.md`*

**Fully tested Dockerfile for using scroll-phat library without needing to install it on base system.**

> This is unobtrusively squirrelled away in the library folder for those who are curious and interested in learning about Docker and the PI. Tested with the count.py example.

Building
```
$ cd library
$ ./docker_build.sh
```

Running in repl
```
$ docker run -ti --privileged scroll-phat
Python 2.7.9 (default, Mar  8 2015, 00:52:26) 
[GCC 4.9.2] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import scrollphat
>>> scrollphat.set_pixel(1,1,True)
>>> scrollphat.update()
>>> 
```

Build an image to run an example file:

**Dockerfile**

```
FROM scroll-phat
CMD ["python", "examples/count.py", "99"]
```

**Build example**
```
docker build -t scroll-phat/count .
```

**Running example**
```
docker run --privileged scroll-phat/count
```

### Testing use-case

* Remove all traces of scroll-phat egg from base system
* Use Dockerfile to run `setup.py install` then run a number of the examples to see whether they are working fully.

* Can easily have an image with only Python2, only Python3 and both - for testing.

Previously this would have involved hacks and work-arounds. 

### Deployment use-case

* Once i2c is configured on the base system, nothing needs to be installed on top at all
* Everything can be installed straight into the image - even at different versions
* Can be used as a base image to be derived from for a personal project with scroll-phat

### Can be used to distribute a tested/working installation

* Maintainer builds image
* Maintainer uploads to Docker Hub
* Consumer/enthusiast pulls image, runs exactly the same as it did for the maintainer.

