### PR TITLE
Refactor to create new Dockerfile without dependencies.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,18 +1,22 @@
-FROM alexellis2/python-gpio:armv6
-# This base image will be fetched automatically from the Docker Hub
-# https://hub.docker.com/r/alexellis2/python-gpio/
+FROM resin/rpi-raspbian
+MAINTAINER alexellis2@gmail.com
+ENTRYPOINT []
 
-# For instructions on installing Docker on the PI Zero visit below tutorial
-# http://blog.alexellis.io/dockerswarm-pizero/
+RUN mkdir -p /root/scroll-phat
+WORKDIR /root/scroll-phat/
 
-RUN apt-get update && \
-    apt-get -qy install python-smbus i2c-tools
+RUN apt-get update \
+    && apt-get install \
+       python-dev \
+       python-smbus \
+       i2c-tools \
+       python-pip \
+       gcc
 
-ADD ./examples  ./examples
-ADD ./library   ./library
-ADD ./tools     ./tools
+COPY ./examples  ./examples
+COPY ./library   ./library
+COPY ./tools     ./examples
 
-RUN cd library && \
-    python setup.py install
+RUN cd library && python setup.py install
 
 CMD ["python"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,15 +1,32 @@
 ### Dockerfile for using the `scrollphat` library without needing to install it on base system.
 
-For instructions on installing Docker on the PI Zero visit https://github.com/alexellis/docker-arm
+To learn how to install Docker on a Pi visit:
 
-Building
+* [Hands-on Docker for Raspberry Pi](http://blog.alexellis.io/hands-on-docker-raspberrypi/)
+
+For a curated collection of tutorials and images for Docker on ARM (Raspberry Pi) visit:
+
+* https://github.com/alexellis/docker-arm
+
+### Building:
+
+Build the local source as a Docker image:
+
 ```
 $ ./build_docker.sh
 ```
 
-Running in repl
+Or build from the master branch on Github with:
+
+```
+$ ./build_docker_git.sh
+```
+
+#### Running in a REPL
+
 ```
 $ docker run -ti --privileged scroll-phat
+
 Python 2.7.9 (default, Mar  8 2015, 00:52:26)
 [GCC 4.9.2] on linux2
 Type "help", "copyright", "credits" or "license" for more information.
@@ -18,6 +35,8 @@ Type "help", "copyright", "credits" or "license" for more information.
 >>> scrollphat.update()
 >>>
 ```
+
+#### Adding your own code
 
 Build an image to run an example file:
 
@@ -29,16 +48,20 @@ CMD ["python", "examples/count.py", "99"]
 ```
 
 **Build example**
+
 ```
 docker build -t scroll-phat/count .
 ```
 
-**Running example**
+**Running an example**
+
 ```
 docker run --privileged scroll-phat/count
 ```
 
-### Testing use-case
+### Use-cases for Docker
+
+#### Testing use-case
 
 * Remove all traces of scroll-phat egg from base system
 * Use Dockerfile to run `setup.py install` then run a number of the examples to see whether they are working fully.
@@ -47,14 +70,13 @@ docker run --privileged scroll-phat/count
 
 Previously this would have involved hacks and work-arounds.
 
-### Deployment use-case
+#### Deployment use-case
 
 * Once i2c is configured on the base system, nothing needs to be installed on top at all
 * Everything can be installed straight into the image - even at different versions
 * Can be used as a base image to be derived from for a personal project with scroll-phat
 
-### Can be used to distribute a tested/working installation
+#### Can be used to distribute a tested/working installation
 
-* Maintainer builds image
-* Maintainer uploads to Docker Hub
-* Consumer/enthusiast pulls image, runs exactly the same as it did for the maintainer.
+Maintainer builds image -> maintainer uploads to Docker Hub -> consumer/enthusiast pulls image, runs exactly the same as it did for the maintainer.
+

--- a/docker/build_docker.sh
+++ b/docker/build_docker.sh
@@ -1,7 +1,9 @@
 echo "Building image to your library as scroll-phat"
+
+# Maintainers do not want Dockerfile at root of repository.
 cp Dockerfile ../
 cd ../
-docker build -t scroll-phat .
-rm Dockerfile
+docker build -t scroll-phat . && rm Dockerfile
+
 
 

--- a/docker/build_docker_git.sh
+++ b/docker/build_docker_git.sh
@@ -1,0 +1,6 @@
+echo "Building image to your library as scroll-phat:master"
+
+# Maintainers do not want Dockerfile at root of repository.
+cp git.Dockerfile ../Dockerfile
+cd ../
+docker build -t scroll-phat:master . && rm Dockerfile

--- a/docker/git.Dockerfile
+++ b/docker/git.Dockerfile
@@ -1,0 +1,18 @@
+FROM resin/rpi-raspbian
+MAINTAINER alexellis2@gmail.com
+
+ENTRYPOINT []
+
+WORKDIR /root/
+
+RUN apt-get update \
+    && apt-get install git python-dev python-smbus i2c-tools python-pip gcc \
+    && git clone https://github.com/pimoroni/scroll-phat \
+    && cd scroll-phat/library && python setup.py install \
+    && apt-get -qy remove python-dev gcc \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /root/scroll-phat/examples
+
+CMD ["python"]
+


### PR DESCRIPTION
Work from https://github.com/pimoroni/scroll-phat/issues/66

* Updated README
* Dockerfile now depends directly on `resin/rpi-raspbian` for easier maintenance.
* Provided two Dockerfiles - one for git/master and one (default) for current git branch.
