### PR TITLE
Typo in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update \
 
 COPY ./examples  ./examples
 COPY ./library   ./library
-COPY ./tools     ./examples
+COPY ./tools     ./tools
 
 RUN cd library && python setup.py install
 


### PR DESCRIPTION
Typo in copy-step "tools" had become "examples"